### PR TITLE
build: Allow all actively supported Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.3"
+          go-version: "1.23.9"
 
       - name: Check gofmt
         run: |
@@ -47,7 +47,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.3"
+          go-version: "1.23.9"
 
       - name: Set up Go environment variables
         run: |
@@ -71,7 +71,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.3"
+          go-version: "1.23.9"
 
       - name: Install dependencies
         run: go mod download
@@ -91,7 +91,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.3"
+          go-version: "1.23.9"
 
       - name: Install dependencies
         run: go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  go: "1.24.3"
+  go: "1.23.9"
   timeout: 10m
 
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image.
-FROM golang:1.24.3 AS build
+FROM golang:1.23.9 AS build
 
 # Install necessary tools and dependencies.
 RUN apt-get update && \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Installation Instructions
 
-### Step 1: Install Go 1.24.3
+### Step 1: Install Go 1.23.9
 
 1. Visit the official Go download page: [Go Downloads](https://go.dev/dl).
 2. Download and install the appropriate version for your OS and hardware architecture.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-continuous-fuzz/go-continuous-fuzz
 
-go 1.24.3
+go 1.23.9
 
 require (
 	github.com/go-git/go-git/v5 v5.16.0


### PR DESCRIPTION
Fixes: #2 

## Description
Relaxed the Go version requirement to include both 1.23.9 and 1.24.3. Updated `go.mod`’s `go` directive and the CI so that we no longer force 1.24.3, since we don’t use any 1.24 specific features and add 1.23.9 to the supported toolchains. 