### PR TITLE
multi: rename binary to go-continuous-fuzz

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 .env
 
-app
+go-continuous-fuzz
 
 out/
 fuzz_results/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .env
 
-app
+go-continuous-fuzz
 
 out/
 fuzz_results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update && \
         make
 
 # Create a directory for cloning the repository.
-RUN mkdir /app
+RUN mkdir /go-continuous-fuzz
 
 # Change current working directory.
-WORKDIR /app
+WORKDIR /go-continuous-fuzz
 
-# Copy the go-continuous-fuzz repo into the /app directory.
+# Copy the go-continuous-fuzz repo into the /go-continuous-fuzz directory.
 COPY . .
 
 # Install Go modules.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Variables
-APP_NAME := app
+APP_NAME := go-continuous-fuzz
 SRC := main.go
 DOCKER_APP_NAME := go-continuous-fuzz
 
-#? build: Build the project and create app binary
+#? build: Build the project and create go-continuous-fuzz binary
 build:
 	@echo "Building $(APP_NAME)..."
 	go build -o $(APP_NAME) $(SRC)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -43,7 +43,7 @@ make build
 
 1. Make sure the required environment variables are set.
    For more details, see: [docs/USAGE.md](USAGE.md)
-2. Run the following command to run the go-continuous-fuzz app:
+2. Run the following command to run the go-continuous-fuzz project:
 
 ```sh
 make run
@@ -51,7 +51,7 @@ make run
 
 ### Step 6: Run the go-continuous-fuzz project in docker
 
-1. Run the following command to run the Continuous-Fuzz app in docker container:
+1. Run the following command to run the go-continuous-fuzz project in docker container:
 
 ```sh
 make docker-run-file ENV_FILE=<required> VOLUME_MOUNTS=<optional>

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -70,7 +70,7 @@ func RunFuzzingCycles(ctx context.Context, logger *slog.Logger, cfg *config.
 }
 
 // runFuzzingWorker executes the fuzzing work until the cycle context is
-// canceled. It repeatedly calls the main fuzzing function from the app package.
+// canceled. It calls the main fuzzing function from the worker package.
 func runFuzzingWorker(ctx context.Context, logger *slog.Logger, cfg *config.
 	Config, doneChan chan struct{}) {
 


### PR DESCRIPTION
Fixes: #12 

## Description
Renamed the project binary from `app` to `go-continuous-fuzz` for clarity. Updated the `.gitignore` and `.dockerignore` files, changed the Docker container’s project directory from `app` to `go-continuous-fuzz`, and revised documentation and code comments to reflect the new name.
