### PR TITLE
Persist corpus between runs and improve e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
 go-continuous-fuzz
-
-out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 go-continuous-fuzz
-
-out/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go-continuous-fuzz is a Go native fuzzing tool that automatically detects and ru
 ## Features
 
 - **Automatic Fuzz Target Detection:** Scans the repository and identifies all available fuzz targets.
-- **Concurrent Fuzzing:** Runs multiple fuzzing processes concurrently, with the default set to the number of available CPU cores.
+- **Concurrent Fuzzing:** Runs multiple fuzzing processes concurrently, with the default set to one CPU core.
 - **Customizable Execution:** Configure the duration and target package for fuzzing with config variables.
 - **Corpus Persistence:** Saves the input corpus for each fuzz target to a specified local directory, ensuring that the test cases are preserved for future runs.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,14 +4,14 @@
 
 You can configure **go-continuous-fuzz** using either conifg file or command-line flags. All options are listed below:
 
-| Configuration Variable | Description                                   | Required | Default |
-| ---------------------- | --------------------------------------------- | -------- | ------- |
-| `project.src-repo`     | Git repo URL of the project to fuzz           | Yes      | —       |
-| `project.storage-repo` | Git repo URL where the input corpus is stored | Yes      | —       |
-| `fuzz.results-path`    | Path to store fuzzing results                 | Yes      | —       |
-| `fuzz.pkgs-path`       | List of package paths to fuzz                 | Yes      | —       |
-| `fuzz.time`            | Duration between consecutive fuzzing cycles   | No       | 120s    |
-| `fuzz.num-processes`   | Number of concurrent fuzzing processes        | No       | 1       |
+| Configuration Variable | Description                                            | Required | Default |
+| ---------------------- | -------------------------------------------------------| -------- | ------- |
+| `project.src-repo`     | Git repo URL of the project to fuzz                    | Yes      | —       |
+| `project.corpus-path`  | Absolute path to directory where seed corpus is stored | Yes      | —       |
+| `fuzz.results-path`    | Path to store fuzzing results                          | Yes      | —       |
+| `fuzz.pkgs-path`       | List of package paths to fuzz                          | Yes      | —       |
+| `fuzz.time`            | Duration between consecutive fuzzing cycles            | No       | 120s    |
+| `fuzz.num-processes`   | Number of concurrent fuzzing processes                 | No       | 1       |
 
 **Repository URL formats:**
 
@@ -49,7 +49,7 @@ You can configure **go-continuous-fuzz** using either conifg file or command-lin
 
    ```bash
      --project.src-repo=<project_repo_url>
-     --project.storage-repo=<storage_repo_url>
+     --project.corpus-path=<path/to/file>
      --fuzz.results-path=<path/to/file>
      --fuzz.pkgs-path=<path/to/pkg>
      --fuzz.time=<time>

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -4,17 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/go-continuous-fuzz/go-continuous-fuzz/config"
 	"github.com/go-continuous-fuzz/go-continuous-fuzz/parser"
-	"github.com/go-continuous-fuzz/go-continuous-fuzz/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -51,7 +48,7 @@ func RunFuzzing(ctx context.Context, logger *slog.Logger,
 			}
 
 			// Discover all fuzz targets in this package (pkg)
-			targets, err := listFuzzTargets(goCtx, logger, pkg)
+			targets, err := listFuzzTargets(goCtx, logger, cfg, pkg)
 			if err != nil {
 				return fmt.Errorf("failed to list targets for"+
 					" package %q: %w", pkg, err)
@@ -110,13 +107,13 @@ func RunFuzzing(ctx context.Context, logger *slog.Logger,
 // package. It uses "go test -list=^Fuzz" to list the functions and filters
 // those that start with "Fuzz".
 func listFuzzTargets(ctx context.Context, logger *slog.Logger,
-	pkg string) ([]string, error) {
+	cfg *config.Config, pkg string) ([]string, error) {
 
 	logger.Info("Discovering fuzz targets", "package", pkg)
 
 	// Construct the absolute path to the package directory within the
-	// default project directory.
-	pkgPath := filepath.Join(config.DefaultProjectDir, pkg)
+	// temporary project directory.
+	pkgPath := filepath.Join(cfg.Project.SrcDir, pkg)
 
 	// Prepare the command to list all test functions matching the pattern
 	// "^Fuzz". This leverages Go's testing tool to identify fuzz targets.
@@ -168,19 +165,12 @@ func executeFuzzTarget(ctx context.Context, logger *slog.Logger, pkg string,
 	logger.Info("Executing fuzz target", "package", pkg, "target", target)
 
 	// Construct the absolute path to the package directory within the
-	// default project directory.
-	pkgPath := filepath.Join(config.DefaultProjectDir, pkg)
-
-	// Retrieve the current working directory.
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
+	// temporary project directory.
+	pkgPath := filepath.Join(cfg.Project.SrcDir, pkg)
 
 	// Define the path to store the corpus data generated during fuzzing.
-	corpusPath := filepath.Join(
-		cwd, config.DefaultCorpusDir, pkg, "testdata", "fuzz",
-	)
+	corpusPath := filepath.Join(cfg.Project.CorpusPath, pkg, "testdata",
+		"fuzz")
 
 	// Define the path where failing corpus inputs might be saved by the
 	// fuzzing process.
@@ -213,26 +203,15 @@ func executeFuzzTarget(ctx context.Context, logger *slog.Logger, pkg string,
 		return fmt.Errorf("command start failed: %w", err)
 	}
 
-	// Channel to signal if the fuzz target encountered a failure.
-	fuzzTargetFailingChan := make(chan bool, 1)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	// Stream and process the standard output of 'go test', which may
 	// include both stdout and stderr content.
-	go streamFuzzOutput(logger.With("target", target).With("package", pkg),
-		&wg, stdout, maybeFailingCorpusPath, cfg, target,
-		fuzzTargetFailingChan)
-
-	// Wait for the output streaming to complete.
-	wg.Wait()
+	processor := parser.NewFuzzOutputProcessor(logger.
+		With("target", target).With("package", pkg), cfg,
+		maybeFailingCorpusPath, target)
+	isFailing := processor.ProcessFuzzStream(stdout)
 
 	// Wait for the 'go test' command to finish execution.
 	err = cmd.Wait()
-
-	// Check if the fuzz target encountered a failure.
-	isFailing := <-fuzzTargetFailingChan
 
 	// Proceed to return an error only if the fuzz target did not fail
 	// (i.e., no failure was detected during fuzzing), and the command
@@ -262,35 +241,5 @@ func executeFuzzTarget(ctx context.Context, logger *slog.Logger, pkg string,
 		"target", target,
 	)
 
-	// If fuzzing was successful, save the corpus data to the specified
-	// directory.
-	utils.SaveFuzzCorpus(logger, cfg, pkg, target)
-
 	return nil
-}
-
-// streamFuzzOutput reads and processes the standard output of a fuzzing
-// process. It utilizes a FuzzOutputProcessor to parse each line of output,
-// identifying any errors or failures that occur during fuzzing. If a failure is
-// detected, it logs the error details and the corresponding failing test case
-// into the log file for analysis. The function signals completion through the
-// provided WaitGroup and communicates whether a failure was encountered via the
-// fuzzTargetFailingChan channel.
-func streamFuzzOutput(logger *slog.Logger, wg *sync.WaitGroup, r io.Reader,
-	corpusPath string, cfg *config.Config, target string,
-	failureChan chan bool) {
-
-	defer wg.Done()
-
-	// Create a FuzzOutputProcessor to handle parsing and logging of fuzz
-	// output.
-	processor := parser.NewFuzzOutputProcessor(logger, cfg, corpusPath,
-		target)
-
-	// Process the fuzzing output stream. This will log all output, detect
-	// failures, and write failure details to disk if encountered.
-	failureDetected := processor.ProcessFuzzStream(r)
-
-	// Communicate the result (failure detected or not) back to the caller.
-	failureChan <- failureDetected
 }

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.23.9
 
 require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
-	github.com/go-git/go-git/v5 v5.16.0
+	github.com/go-git/go-git/v5 v5.16.1
 	github.com/jessevdk/go-flags v1.6.1
-	github.com/otiai10/copy v1.14.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.14.0
 )
@@ -28,7 +27,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
-github.com/go-git/go-git/v5 v5.16.0/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.1 h1:TuxMBWNL7R05tXsUGi0kh1vi4tq0WfXNLlIrAkXG1k8=
+github.com/go-git/go-git/v5 v5.16.1/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -109,10 +109,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/otiai10/copy v1.14.1 h1:5/7E6qsUMBaH5AnQ0sSLzzTg1oTECmcCmT6lvF45Na8=
-github.com/otiai10/copy v1.14.1/go.mod h1:oQwrEDDOci3IM8dJF0d8+jnbfPDllW6vUjNc3DoZm9I=
-github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=
-github.com/otiai10/mint v1.6.3/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/sample-go-continuous-fuzz.conf
+++ b/sample-go-continuous-fuzz.conf
@@ -17,14 +17,11 @@
 ;  For a public GitHub repository:
 ;   project.src-repo = https://github.com/<OWNER>/<REPO>.git
 
-; Git URL where the input corpus is stored.
+; Absolute path to directory where seed corpus is stored.
 ; Default:
-;   project.storage-repo =
+;   project.corpus-path =
 ; Example:
-;  For a private GitHub repository:
-;   project.storage-repo = https://oauth2:<PAT>@github.com/<OWNER>/<REPO>.git
-;  For a public GitHub repository:
-;   project.storage-repo = https://github.com/<OWNER>/<REPO>.git
+;   project.corpus-path = ~/corpus
 
 [Fuzz Options]
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -50,7 +50,7 @@ func RunFuzzingCycles(ctx context.Context, logger *slog.Logger, cfg *config.
 			// wait before the fuzzing worker is closed before
 			// cleanup.
 			<-doneChan
-			utils.CleanupWorkspace(logger)
+			utils.CleanupWorkspace(logger, cfg)
 
 		case <-ctx.Done():
 			logger.Info("Shutdown initiated during fuzzing " +
@@ -62,7 +62,7 @@ func RunFuzzingCycles(ctx context.Context, logger *slog.Logger, cfg *config.
 			// wait before the fuzzing worker is closed before
 			// cleanup.
 			<-doneChan
-			utils.CleanupWorkspace(logger)
+			utils.CleanupWorkspace(logger, cfg)
 
 			return
 		}

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,36 +1,200 @@
 #!/bin/bash
 
-set -x
+set -eux
 
-# Specify the command-line flags for the fuzzing process
+# ====== CONFIGURATION ======
+
+# Temporary Variables
+readonly PROJECT_SRC_PATH="https://github.com/go-continuous-fuzz/go-fuzzing-example.git"
+readonly FUZZ_TIME="3m"
+readonly MAKE_TIMEOUT="5m"
+
+# Use test workspace directory
+readonly TEST_WORKDIR=$(mktemp -dt "test-go-continuous-fuzz-XXXXXX")
+readonly PROJECT_DIR="${TEST_WORKDIR}/project"
+readonly CORPUS_DIR_PATH="${TEST_WORKDIR}/corpus"
+readonly FUZZ_RESULTS_PATH="${TEST_WORKDIR}/fuzz_results"
+
+# Command-line flags for fuzzing process configuration
 ARGS="\
---project.src-repo=https://github.com/lightningnetwork/lnd.git \
---project.storage-repo=https://github.com/lightninglabs/lnd-fuzz.git \
---fuzz.time=1700s \
---fuzz.results-path=~/fuzz_results \
---fuzz.pkgs-path=macaroons \
---fuzz.pkgs-path=routing \
---fuzz.pkgs-path=watchtower/wtclient \
---fuzz.pkgs-path=watchtower/wtwire \
---fuzz.pkgs-path=zpay32"
+--project.src-repo=${PROJECT_SRC_PATH} \
+--project.corpus-path=${CORPUS_DIR_PATH} \
+--fuzz.time=${FUZZ_TIME} \
+--fuzz.results-path=${FUZZ_RESULTS_PATH} \
+--fuzz.pkgs-path=parser \
+--fuzz.pkgs-path=stringutils"
 
-# Run the make command with a 30-minute timeout
-timeout -s INT --preserve-status 30m make run ARGS="$ARGS"
-EXIT_STATUS=$?
+# Fuzz target definitions (package:function)
+readonly FUZZ_TARGETS=(
+  "parser:FuzzParseComplex"
+  "parser:FuzzEvalExpr"
+  "stringutils:FuzzUnSafeReverseString"
+  "stringutils:FuzzReverseString"
+)
 
-# If make run failed (not timeout and SIGINT), exit with error
-if [ $EXIT_STATUS -ne 0 ] && [ $EXIT_STATUS -ne 130 ]; then
-  echo "❌ The operation exited with status $EXIT_STATUS."
-  exit $EXIT_STATUS
+# Ensure that resources are cleaned up when the script exits
+trap 'echo "Cleaning up resources..."; rm -rf "${TEST_WORKDIR}"' EXIT
+
+# ====== FUNCTION DEFINITIONS ======
+
+# Counts the number of test inputs in a corpus directory
+# Arguments:
+#   $1 - Package name
+#   $2 - Function name
+# Returns: Number of input files
+count_corpus_inputs() {
+  local pkg="$1"
+  local func="$2"
+
+  local dir="${CORPUS_DIR_PATH}/${pkg}/testdata/fuzz/${func}"
+
+  if [[ -d "${dir}" ]]; then
+    local num_inputs=$(ls "${dir}" | wc -l)
+    echo ${num_inputs}
+  else
+    echo 0
+  fi
+}
+
+# Measures the code coverage for a fuzz target
+# Arguments:
+#   $1 - Package name
+#   $2 - Function name
+# Returns: Coverage percentage value
+measure_fuzz_coverage() {
+  local pkg="$1"
+  local func="$2"
+  local coverage_result
+
+  cd "${PROJECT_DIR}/${pkg}"
+
+  # Enable Go fuzzing debug output
+  export GODEBUG="fuzzdebug=1"
+
+  # Count existing corpus inputs
+  local num_inputs=$(count_corpus_inputs "${pkg}" "${func}")
+
+  # Run coverage measurement
+  coverage_result=$(go test -run="^${func}$" -fuzz="^${func}$" \
+    -fuzztime="${num_inputs}x" \
+    -test.fuzzcachedir="${CORPUS_DIR_PATH}/${pkg}/testdata/fuzz" |
+    grep "initial coverage bits:" | grep -oE "[0-9]+$")
+
+  echo "${coverage_result}"
+}
+
+# ====== MAIN EXECUTION ======
+
+# Clone the target repository
+echo "Cloning project repository..."
+git clone "${PROJECT_SRC_PATH}" "${PROJECT_DIR}"
+
+# Download and extract only the seed_corpus directory from the project tarball
+echo "Downloading seed corpus..."
+mkdir -p ${CORPUS_DIR_PATH}
+curl -L https://codeload.github.com/go-continuous-fuzz/go-fuzzing-example/tar.gz/main | \
+  tar -xz --strip-components=2 -C ${CORPUS_DIR_PATH} go-fuzzing-example-main/seed_corpus
+
+# Initialize data stores
+declare -A initial_input_counts
+declare -A initial_coverage_metrics
+declare -A final_input_counts
+declare -A final_coverage_metrics
+
+# Capture initial corpus state
+echo "Recording initial corpus state..."
+for target in "${FUZZ_TARGETS[@]}"; do
+  IFS=':' read -r pkg func <<<"${target}"
+  echo "  - ${pkg}/${func}"
+  initial_input_counts["${target}"]=$(count_corpus_inputs "${pkg}" "${func}")
+  initial_coverage_metrics["${target}"]=$(measure_fuzz_coverage "${pkg}" "${func}")
+done
+
+# Execute fuzzing process
+echo "Starting fuzzing process (timeout: ${MAKE_TIMEOUT})..."
+mkdir -p "${FUZZ_RESULTS_PATH}"
+MAKE_LOG="${FUZZ_RESULTS_PATH}/make_run.log"
+
+# Run make run under timeout, capturing stdout+stderr into MAKE_LOG.
+timeout -s INT --preserve-status "${MAKE_TIMEOUT}" make run ARGS="${ARGS}" 2>&1 | tee "${MAKE_LOG}"
+status=${PIPESTATUS[0]}
+
+# Handle exit codes:
+#   130 → timeout sent SIGINT; treat as expected termination
+#   any other non-zero → unexpected error
+if [[ ${status} -ne 130 ]]; then
+  echo "❌ Fuzzing exited with unexpected error (status: ${status})."
+  exit "${status}"
 fi
 
-# Check if the $HOME/fuzz_results directory exists
-if [ -d "$HOME/fuzz_results" ]; then
-  echo "✅ Fuzzing process completed successfully."
-else
-  echo "❌ Fuzzing process failed."
-  exit 1
-fi
+# List of required patterns to check in the log
+readonly REQUIRED_PATTERNS=(
+  'Cycle duration complete; initiating cleanup.'
+  'Fuzzing completed successfully'
+  'gathering baseline coverage'
+  'Shutdown initiated during fuzzing cycle; performing final cleanup.'
+)
 
-# Cleanup: Delete the $HOME/fuzz_results directory
-rm -rf "$HOME/fuzz_results"
+# Verify that worker logs contain expected entries
+echo "Verifying worker log entries in ${MAKE_LOG}..."
+for pattern in "${REQUIRED_PATTERNS[@]}"; do
+  if ! grep -q -- "${pattern}" "${MAKE_LOG}"; then
+    echo "❌ ERROR: Missing expected log entry: ${pattern}"
+    exit 1
+  fi
+done
+
+# Capture final corpus state
+echo "Recording final corpus state..."
+for target in "${FUZZ_TARGETS[@]}"; do
+  IFS=':' read -r pkg func <<<"${target}"
+  echo "  - ${pkg}/${func}"
+  final_input_counts["${target}"]=$(count_corpus_inputs "${pkg}" "${func}")
+  final_coverage_metrics["${target}"]=$(measure_fuzz_coverage "${pkg}" "${func}")
+done
+
+# Validate corpus growth
+echo "Validating corpus growth..."
+for target in "${FUZZ_TARGETS[@]}"; do
+  initial_count=${initial_input_counts["${target}"]}
+  final_count=${final_input_counts["${target}"]}
+
+  if [[ ${final_count} -le ${initial_count} ]]; then
+    echo "❌ ERROR: ${target} regressed - inputs decreased from ${initial_count} to ${final_count}"
+    exit 1
+  fi
+done
+
+# Validate coverage metrics
+echo "Validating coverage metrics..."
+for target in "${FUZZ_TARGETS[@]}"; do
+  initial_cov=${initial_coverage_metrics["${target}"]}
+  final_cov=${final_coverage_metrics["${target}"]}
+
+  if [[ ${final_cov} -le ${initial_cov} ]]; then
+    echo "❌ ERROR: ${target} coverage decreased from ${initial_cov} to ${final_cov}"
+    exit 1
+  fi
+done
+
+# Verify crash reports
+echo "Checking crash reports..."
+required_crashes=(
+  "${FUZZ_RESULTS_PATH}/FuzzParseComplex_failure.log"
+  "${FUZZ_RESULTS_PATH}/FuzzUnSafeReverseString_failure.log"
+)
+
+for crash_file in "${required_crashes[@]}"; do
+  if [[ ! -f "${crash_file}" ]]; then
+    echo "❌ ERROR: Missing crash report: ${crash_file}"
+    exit 1
+  fi
+
+  if ! grep -q "go test fuzz v1" "${crash_file}"; then
+    echo "❌ ERROR: Invalid crash report format in ${crash_file}"
+    exit 1
+  fi
+done
+
+echo "✅ Fuzzing process completed successfully."
+exit 0

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,50 +8,18 @@ import (
 	"path/filepath"
 
 	"github.com/go-continuous-fuzz/go-continuous-fuzz/config"
-	"github.com/otiai10/copy"
 )
 
-// CleanupWorkspace deletes the "out" directory to reset the workspace state.
+// CleanupWorkspace deletes the temp directory to reset the workspace state.
 // Any errors encountered during removal are logged, but do not stop execution.
-func CleanupWorkspace(logger *slog.Logger) {
-	if err := os.RemoveAll("out"); err != nil {
+func CleanupWorkspace(logger *slog.Logger, cfg *config.Config) {
+	// Since the config has the path to the project directory and we want to
+	// remove its temporary parent directory, we go up one level to its
+	// parent directory.
+	parentDir := filepath.Dir(cfg.Project.SrcDir)
+	if err := os.RemoveAll(parentDir); err != nil {
 		logger.Error("workspace cleanup failed", "error", err)
 	}
-}
-
-// SaveFuzzCorpus copies the generated corpus data for a given package and
-// target to the configured fuzz results directory. If the corpus directory does
-// not exist, it logs an informational message and returns. Any errors during
-// directory creation or copying are logged and cause the process to exit.
-func SaveFuzzCorpus(logger *slog.Logger, cfg *config.Config, pkg,
-	target string) {
-
-	corpusPath := filepath.Join(config.DefaultCorpusDir, pkg, "testdata",
-		"fuzz", target)
-	if _, err := os.Stat(corpusPath); os.IsNotExist(err) {
-		logger.Info("No corpus directory to output", "path", corpusPath)
-		return
-	}
-
-	// Ensure the FuzzResultsPath directory exists (creates parents as
-	// needed)
-	fuzzResultsPath := filepath.Join(cfg.Fuzz.ResultsPath, pkg, "testdata",
-		"fuzz", target)
-	if err := EnsureDirExists(fuzzResultsPath); err != nil {
-		logger.Error("failed to create fuzz results directory", "error",
-			err, "path", fuzzResultsPath)
-		os.Exit(1)
-	}
-
-	// Copy corpus to the results directory
-	if err := copy.Copy(corpusPath, fuzzResultsPath); err != nil {
-		logger.Error("failed to copy corpus", "error", err, "from",
-			corpusPath, "to", fuzzResultsPath)
-		os.Exit(1)
-	}
-
-	logger.Info("Successfully updated corpus directory", "path",
-		fuzzResultsPath, "pkg", pkg, "target", target)
 }
 
 // EnsureDirExists creates the specified directory and all necessary parents if

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -12,23 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
-func clone(ctx context.Context, logger *slog.Logger, desc, path,
-	url string) error {
-
-	logger.Info("Cloning repository", "url", utils.SanitizeURL(url), "path",
-		path, "desc", desc)
-
-	_, err := git.PlainCloneContext(
-		ctx, path, false, &git.CloneOptions{URL: url},
-	)
-	if err != nil {
-		return fmt.Errorf("%s repository clone failed: %w", desc, err)
-	}
-
-	return nil
-}
-
-// Main handles the cloning of repositories and the execution of fuzz testing.
+// Main handles the cloning of repository and the execution of fuzz testing.
 // It ensures that any errors encountered during these processes are logged and
 // that the workspace is cleaned up appropriately before the program exits.
 func Main(ctx context.Context, logger *slog.Logger, cfg *config.Config,
@@ -39,24 +22,20 @@ func Main(ctx context.Context, logger *slog.Logger, cfg *config.Config,
 	defer close(doneChan)
 
 	// Clone the project repository based on the provided configuration.
-	if err := clone(ctx, logger, "project", config.DefaultProjectDir,
-		cfg.Project.SrcRepo); err != nil {
-		logger.Error("Repository cloning failed", "error", err)
+	logger.Info("Cloning project repository", "url", utils.SanitizeURL(
+		cfg.Project.SrcRepo), "path", cfg.Project.SrcDir)
+
+	_, err := git.PlainCloneContext(
+		ctx, cfg.Project.SrcDir, false, &git.CloneOptions{
+			URL: cfg.Project.SrcRepo,
+		},
+	)
+	if err != nil {
+		logger.Error("Project repository cloning failed", "error", err)
 
 		// Perform workspace cleanup before exiting due to the cloning
 		// error.
-		utils.CleanupWorkspace(logger)
-		os.Exit(1)
-	}
-
-	// Clone the storage repository based on the provided configuration.
-	if err := clone(ctx, logger, "storage", config.DefaultCorpusDir,
-		cfg.Project.StorageRepo); err != nil {
-		logger.Error("Repository cloning failed", "error", err)
-
-		// Perform workspace cleanup before exiting due to the cloning
-		// error.
-		utils.CleanupWorkspace(logger)
+		utils.CleanupWorkspace(logger, cfg)
 		os.Exit(1)
 	}
 
@@ -66,7 +45,7 @@ func Main(ctx context.Context, logger *slog.Logger, cfg *config.Config,
 
 		// Perform workspace cleanup before exiting due to the fuzzing
 		// error.
-		utils.CleanupWorkspace(logger)
+		utils.CleanupWorkspace(logger, cfg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes: #3 
Fixes: #6 
Fixes: #7 
Fixes: #9 
Fixes: #13 

## Description

This PR includes the following changes:

* Renamed the constant `DefaultProjectDir` to `TmpProjectDir` since config constants cannot be changed.
* Replaced the use of the current working directory with a temporary directory created via `os.MkdirTemp`. The project to be fuzzed is cloned into this directory, which is safely deleted once the fuzzing cycle completes.
* Instead of requiring a Git-based storage repo URL to fetch the corpus, the user now provides a local corpus directory (via `project.corpus-path`). New inputs are automatically added to this directory in each run.
* Removed the need for `utils.SaveFuzzCorpus`, as the corpus is now automatically persisted after each fuzzing cycle.
* Updated the e2e tests to ensure broader coverage of the fuzzing process.