### PR TITLE
parser: add fallback message for missing failing input

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -18,13 +18,6 @@ func TestParseFailureLine(t *testing.T) {
 		expectedID     string
 	}{
 		{
-			name: "Seed corpus failure log line",
-			logLine: "failure while testing seed corpus " +
-				"entry: FuzzFoo/771e938e4458e983",
-			expectedTarget: "FuzzFoo",
-			expectedID:     "771e938e4458e983",
-		},
-		{
 			name: "Fuzzing failure log with saved input " +
 				"path",
 			logLine: "Failing input written to testdata/fuzz" +


### PR DESCRIPTION
We do not need to parse the regexp `failure while testing seed corpus entry: FuzzFoo/771e938e4458e983`, because it only appears when a fuzzing crash has already been reported and the failing input is saved in `testdata/fuzz/FuzzFoo/771e938e4458e983` in the fuzz target directory. If we rerun fuzzing without removing this file and without fixing the underlying issue, the same message will appear again. Since we remove this corpus entry once we receive the crash, we can safely drop this regexp.

For crashes caused by a seed corpus entry added via `f.Add`, we will fall back to the following error message:

```text
=== Failing Testcase ===
Failure occurred while testing the seed corpus; please check the entries added via f.Add.
```