### PR TITLE
Perform crash deduplication

### DIFF
--- a/container.go
+++ b/container.go
@@ -115,7 +115,8 @@ func (c *Container) WaitAndGetLogs(ID, pkg, target string,
 	// Process the standard output, which may include both stdout and stderr
 	// content.
 	processor := NewFuzzOutputProcessor(c.logger.With("target", target).
-		With("package", pkg), c.cfg, maybeFailingCorpusPath, target)
+		With("package", pkg), c.cfg, maybeFailingCorpusPath, pkg,
+		target)
 	crashed := processor.processFuzzStream(logsReader)
 
 	// Fuzz target crashed: notify via failingChan.

--- a/parser.go
+++ b/parser.go
@@ -26,6 +26,19 @@ var (
 		`Failing input written to testdata/fuzz/` +
 			`(?P<target>[^/]+)/(?P<id>[0-9a-f]+)`,
 	)
+
+	// fuzzFileLineRegex matches a stack-trace line indicating a fuzzing
+	// error, capturing the .go file name and line number.
+	//
+	// It matches lines like:
+	//   "stringutils_test.go:17: Reverse produced invalid UTF-8 string"
+	//
+	// Captured groups:
+	//   - "file": the .go file name (e.g., "stringutils_test.go")
+	//   - "line": the line number (e.g., "17")
+	fuzzFileLineRegex = regexp.MustCompile(
+		`\s*(?P<file>[^/]+\.(?:go)):(?P<line>[0-9]+)`,
+	)
 )
 
 // fuzzOutputProcessor handles parsing and logging of fuzzing output streams,
@@ -40,20 +53,24 @@ type fuzzOutputProcessor struct {
 	// Directory containing the fuzzing corpus.
 	corpusDir string
 
+	// Name of the package under test.
+	packageName string
+
 	// Name of the fuzz target under test.
 	targetName string
 }
 
 // NewFuzzOutputProcessor constructs a fuzzOutputProcessor for the given logger,
 // config, corpus directory, and fuzz target name.
-func NewFuzzOutputProcessor(logger *slog.Logger, cfg *Config,
-	corpusDir string, targetName string) *fuzzOutputProcessor {
+func NewFuzzOutputProcessor(logger *slog.Logger, cfg *Config, corpusDir, pkg,
+	targetName string) *fuzzOutputProcessor {
 
 	return &fuzzOutputProcessor{
-		logger:     logger,
-		cfg:        cfg,
-		corpusDir:  corpusDir,
-		targetName: targetName,
+		logger:      logger,
+		cfg:         cfg,
+		corpusDir:   corpusDir,
+		packageName: pkg,
+		targetName:  targetName,
 	}
 }
 
@@ -92,46 +109,25 @@ func (fp *fuzzOutputProcessor) scanUntilFailure(scanner *bufio.Scanner) bool {
 // processFailureLines processes lines after a failure is detected, writes them
 // to a log file, and attempts to extract and log the failing input data.
 func (fp *fuzzOutputProcessor) processFailureLines(scanner *bufio.Scanner) {
-	// Construct the log file path for storing failure details.
-	logFileName := fmt.Sprintf("%s_failure.log", fp.targetName)
-	logPath := filepath.Join(fp.cfg.Fuzz.ResultsPath, logFileName)
-
-	// Ensure the results directory exists.
-	if err := EnsureDirExists(fp.cfg.Fuzz.ResultsPath); err != nil {
-		fp.logger.Error("Failed to create fuzz results directory",
-			"error", err)
-		return
-	}
-
-	// Create the log file for writing.
-	logFile, err := os.Create(logPath)
-	if err != nil {
-		fp.logger.Error("Failed to create log file", "error", err)
-		return
-	}
-
-	// Ensure the log file is closed at the end.
-	defer func() {
-		if err := logFile.Close(); err != nil {
-			fp.logger.Error("Failed to close log file", "error",
-				err)
-		}
-	}()
-
-	fp.logger.Info("Opened failure log for writing", "path", logPath)
-
+	var failingLog string
 	var failingInputString string
+	var failingFileLine string
 
 	for scanner.Scan() {
 		line := scanner.Text()
 		fp.logger.Info("Fuzzer output", "message", line)
 
-		// Write the current line to the failure log file.
-		_, err = logFile.WriteString(line + "\n")
-		if err != nil {
-			fp.logger.Error("Failed to write log line", "error",
-				err)
-			return
+		// Write the current line to the failure log.
+		failingLog = failingLog + line + "\n"
+
+		// failingFileLine stores the .go file and line where an error
+		// occurred for deduplication.
+		// Parse the current error line to extract the .go file and line
+		// then append them to failingFileLine.
+		errorFileAndLine := parseFileAndLine(line)
+		if errorFileAndLine != "" {
+			failingFileLine = failingFileLine + errorFileAndLine +
+				"\n"
 		}
 
 		// If error data has already been captured, skip further
@@ -172,13 +168,125 @@ func (fp *fuzzOutputProcessor) processFailureLines(scanner *bufio.Scanner) {
 		)
 	}
 
+	// Ensure the results directory exists.
+	if err := EnsureDirExists(fp.cfg.Fuzz.ResultsPath); err != nil {
+		fp.logger.Error("Failed to create fuzz results directory",
+			"error", err)
+		return
+	}
+
+	// Check if the crash has already been recorded to avoid duplicate
+	// logging.
+	isKnown, logFileName, err := fp.isCrashDuplicate(failingFileLine)
+	if err != nil {
+		fp.logger.Error("Failed to perform crash deduplication",
+			"error", err)
+		return
+	}
+	if isKnown {
+		fp.logger.Info("Known crash detected. Please fix the failing "+
+			"testcase.", "log_file", logFileName)
+		return
+	}
+
+	// A new unique crash has been detected. Proceed to log the crash
+	// details.
+	if err := fp.writeCrashLog(logFileName, failingLog,
+		failingInputString); err != nil {
+		fp.logger.Error("Failed to write crash log", "error", err)
+		return
+	}
+}
+
+// isCrashDuplicate checks whether a crash with the same hash has already been
+// logged. Returns true if the crash is already known, false otherwise, along
+// with the generated log file name.
+func (fp *fuzzOutputProcessor) isCrashDuplicate(errorData string) (bool,
+	string, error) {
+
+	// Compute a short signature hash for the crash to help with
+	// deduplication.
+	crashHash := ComputeSHA256Short(fp.packageName, fp.targetName,
+		errorData)
+
+	// Construct the log file name using the package, target name and crash
+	// hash.
+	logFileName := fmt.Sprintf("%s_%s_%s_failure.log", fp.packageName,
+		fp.targetName, crashHash)
+
+	// Check if a log file with the same signature already exists in the
+	// fuzz results directory.
+	isKnown, err := FileExistsInDir(fp.cfg.Fuzz.ResultsPath, logFileName)
+	if err != nil {
+		return false, "", fmt.Errorf("checking for existing crash "+
+			"log: %w", err)
+	}
+
+	return isKnown, logFileName, nil
+}
+
+// writeCrashLog writes crash logs into a file at the cfg.Fuzz.ResultsPath
+// location.
+func (fp *fuzzOutputProcessor) writeCrashLog(logFileName, failingLog,
+	failingInputString string) error {
+
+	// Construct the log file path for storing failure details.
+	logPath := filepath.Join(fp.cfg.Fuzz.ResultsPath, logFileName)
+
+	// Create the log file for writing.
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("Failed to create log file: %w", err)
+	}
+
+	// Ensure the log file is closed at the end.
+	defer func() {
+		if err := logFile.Close(); err != nil {
+			fp.logger.Error("Failed to close log file", "error",
+				err)
+		}
+	}()
+
+	fp.logger.Info("Opened failure log for writing", "path", logPath)
+
+	// Write the error logs to the failure log file.
+	_, err = logFile.WriteString(failingLog)
+	if err != nil {
+		return fmt.Errorf("failed to write log line: %w", err)
+	}
+
 	// Write the error data to the log file.
 	_, err = logFile.WriteString(failingInputString + "\n")
 	if err != nil {
-		fp.logger.Error("Failed to write error data", "error",
-			err)
-		return
+		return fmt.Errorf("failed to write error data: %w", err)
 	}
+
+	return nil
+}
+
+// parseFileAndLine attempts to extract stack-trace line indicating a fuzzing
+// error, capturing the .go file name and line number.
+func parseFileAndLine(errorLine string) string {
+	// Apply the regular expression to the line to find matches
+	matches := fuzzFileLineRegex.FindStringSubmatch(errorLine)
+
+	// Return empty strings if no match is found
+	if matches == nil {
+		return ""
+	}
+
+	var file, line string
+	// Iterate over the named subexpressions to assign values of file and
+	// line.
+	for i, name := range fuzzFileLineRegex.SubexpNames() {
+		switch name {
+		case "file":
+			file = matches[i]
+		case "line":
+			line = matches[i]
+		}
+	}
+	return file + ":" + line
 }
 
 // parseFailureLine attempts to extract the fuzz target name and input ID

--- a/parser_test.go
+++ b/parser_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestParseFileAndLine verifies that parseFileAndLine correctly extracts
+// the .go file and line where error occurs from various fuzzing log formats.
+func TestParseFileAndLine(t *testing.T) {
+	tests := []struct {
+		name                string
+		logLine             string
+		expectedFileAndLine string
+	}{
+		{
+			name: "non relevant log line",
+			logLine: "--- FAIL: FuzzParseComplex " +
+				"(0.00s)",
+			expectedFileAndLine: "",
+		},
+		{
+			name: "custom error output format",
+			logLine: "      stringutils_test.go:17: " +
+				"Reverse produced invalid UTF-8 string",
+			expectedFileAndLine: "stringutils_test.go:17",
+		},
+		{
+			name: "stack-trace line format",
+			logLine: "go@1.23/1.23.9/libexec/src/" +
+				"testing/fuzz.go:322 +0x49c",
+			expectedFileAndLine: "fuzz.go:322",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualFileAndLine := parseFileAndLine(tt.logLine)
+			assert.Equal(
+				t, tt.expectedFileAndLine, actualFileAndLine,
+				"extracted file and line did not match",
+			)
+		})
+	}
+}
+
 // TestParseFailureLine verifies that parseFailureLine correctly extracts
 // the fuzzing target name and data ID from various fuzzing log formats.
 func TestParseFailureLine(t *testing.T) {
@@ -87,7 +126,7 @@ func TestReadInputData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			processor := NewFuzzOutputProcessor(&slog.Logger{},
-				&Config{}, tt.corpusPath, "")
+				&Config{}, tt.corpusPath, "", "")
 
 			actualData := processor.readFailingInput(tt.fuzzTarget,
 				tt.testcaseID)

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -32,13 +32,6 @@ readonly NON_CRASHING_FUZZ_TARGETS=(
   "stringutils:FuzzReverseString"
 )
 
-# Crashing fuzz target definitions (function)
-readonly CRASHING_FUZZ_TARGETS=(
-  "FuzzParseComplex"
-  "FuzzUnSafeReverseString"
-  "FuzzBuildTree"
-)
-
 # Ensure that resources are cleaned up when the script exits
 trap 'echo "Cleaning up resources..."; rm -rf "${TEST_WORKDIR}"' EXIT
 
@@ -147,6 +140,9 @@ readonly REQUIRED_PATTERNS=(
   'msg="Worker starting fuzz target" workerID=2'
   'msg="Worker starting fuzz target" workerID=3'
   'msg="Per-target fuzz timeout calculated" duration=1m30s'
+  'msg="Known crash detected. Please fix the failing testcase." target=FuzzParseComplex package=parser log_file=parser_FuzzParseComplex_342a5c470d17be27_failure.log'
+  'msg="Known crash detected. Please fix the failing testcase." target=FuzzUnSafeReverseString package=stringutils log_file=stringutils_FuzzUnSafeReverseString_0345b61f9a8eecc9_failure.log'
+  'msg="Known crash detected. Please fix the failing testcase." target=FuzzBuildTree package=tree log_file=tree_FuzzBuildTree_0f94461f591af62b_failure.log'
 )
 
 # Verify that worker logs contain expected entries
@@ -216,8 +212,13 @@ if [[ "${num_crash_files}" -ne 4 ]]; then
   exit 1
 fi
 
-for target in "${CRASHING_FUZZ_TARGETS[@]}"; do
-  crash_file=""${FUZZ_RESULTS_PATH}/${target}_failure.log""
+required_crashes=(
+  "$FUZZ_RESULTS_PATH/parser_FuzzParseComplex_342a5c470d17be27_failure.log"
+  "$FUZZ_RESULTS_PATH/stringutils_FuzzUnSafeReverseString_0345b61f9a8eecc9_failure.log"
+  "$FUZZ_RESULTS_PATH/tree_FuzzBuildTree_0f94461f591af62b_failure.log"
+)
+
+for crash_file in "${required_crashes[@]}"; do
   if [[ ! -f "${crash_file}" ]]; then
     echo "❌ ERROR: Missing crash report: ${crash_file}"
     exit 1

--- a/utils_test.go
+++ b/utils_test.go
@@ -66,3 +66,20 @@ func TestCalculateFuzzSeconds(t *testing.T) {
 		"calculated fuzz duration does not match expected value",
 	)
 }
+
+// TestComputeSHA256Short verifies that ComputeSHA256Short correctly computes a
+// short SHA256 hash based on the package name, fuzz target, and error data.
+// This test ensures that deduplication logic based on this hash remains stable
+// and predictable.
+func TestComputeSHA256Short(t *testing.T) {
+	packageName := "stringutils"
+	targetName := "FuzzUnSafeReverseString"
+	errorData := "stringutils_test.go:17\n"
+
+	expectedHash := "0345b61f9a8eecc9"
+	actualHash := ComputeSHA256Short(packageName, targetName,
+		errorData)
+
+	assert.Equal(t, expectedHash, actualHash, "Computed hash does not "+
+		"match the expected value")
+}


### PR DESCRIPTION
ref: #24 

This commit adds crash‑deduplication logic ahead of our automatic gitHub‑issue creation feature to prevent duplicate issues.

Specifically, it:

1. Parses the failure stack trace to extract each `<file:line>`.
2. Computes a SHA‑256 hash over the package, target, and the concatenated list of `<file:line>\n<File:line>…`.
3. Uses the first 16 characters of that hash to check whether this crash has already been reported.
