### PR TITLE
Add support for corpus minimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ go-continuous-fuzz is a Go native fuzzing tool that automatically detects and ru
 - **Corpus Persistence:** Saves the input corpus for each fuzz target to a specified AWS S3 bucket, ensuring that test cases are preserved for future runs.
 - **Crash Reporting:** Automatically open a GitHub issue on crash, including the error logs and failing input data.
 - **Coverage Reports:** Saves the generated coverage reports for each fuzz target to the specified AWS S3 bucket, enabling coverage history comparison to help improve fuzz targets.
+- **Corpus Minimization:** Periodically remove inputs that do not improve or reduce coverage to prevent corpus bloat.
 
 ## Deployment & Execution
 

--- a/config.go
+++ b/config.go
@@ -88,7 +88,7 @@ type Project struct {
 
 // Fuzz defines all fuzzing-related flags and defaults, including the Git
 // repository URLs of the project where issues will be opened, which packages to
-// fuzz, timeout settings, and concurrency parameters.
+// fuzz, timeout settings, concurrency parameters and corpus minimize interval.
 //
 //nolint:lll
 type Fuzz struct {
@@ -99,6 +99,8 @@ type Fuzz struct {
 	SyncFrequency time.Duration `long:"sync-frequency" description:"Duration between consecutive fuzzing cycles" default:"24h"`
 
 	NumWorkers int `long:"num-workers" description:"Number of concurrent fuzzing workers" default:"1"`
+
+	CorpusMinimizeInterval time.Duration `long:"corpus-minimize-interval" description:"Interval between consecutive corpus minimizations" default:"7d"`
 }
 
 // Config encapsulates all top-level configuration parameters required to run

--- a/corpus.go
+++ b/corpus.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+// MeasureCoverage runs a Go fuzz target using the inputs from its corpus
+// directory and returns the best observed coverage (in coverage bits).
+//
+// It does this by:
+//  1. Reading the corpus files for the given target.
+//  2. Running `go test` with one fuzz iteration per file.
+//  3. Extracting the coverage bits from the command output.
+func MeasureCoverage(ctx context.Context, pkgDir, corpusDir,
+	target string) (int, error) {
+
+	// Gather existing corpus files to size the fuzz run
+	corpusTargetDir := filepath.Join(corpusDir, target)
+	files, err := os.ReadDir(corpusTargetDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("reading corpus dir: %w", err)
+	}
+
+	// Build and run the fuzz command.
+	// Command arguments (explanations):
+	//
+	//   -run=^%s$ -fuzz=^%s$
+	// When the -fuzz flag is provided, `go test` normally runs all unit
+	// tests before doing any fuzzing. Passing -run together with -fuzz
+	// skips the initial unit-test run so we only exercise the fuzz target.
+	//
+	//   -fuzztime=%dx
+	// Set fuzztime to exactly the number of inputs in the corpus directory
+	// so the Go fuzzing engine stops after measuring baseline coverage and
+	// does not perform any actual fuzzing iterations.
+	//
+	//   -test.fuzzcachedir=%s
+	// Use a dedicated fuzz cache directory to avoid cross-contamination
+	// with the default cache.
+	fuzzCmd := []string{"test",
+		fmt.Sprintf("-run=^%s$", target),
+		fmt.Sprintf("-fuzz=^%s$", target),
+		fmt.Sprintf("-fuzztime=%dx", len(files)),
+		fmt.Sprintf("-test.fuzzcachedir=%s", corpusDir),
+	}
+
+	// Run the go test command with GODEBUG to enable fuzzdebug output.
+	//
+	// When GODEBUG=fuzzdebug=1 is set, the Go fuzzing engine prints extra
+	// diagnostic information. We look for the line printed after all inputs
+	// in the fuzz cache have been processed, for example:
+	//   DEBUG finished processing ... initial coverage bits: XXX
+	output, err := runGoCommand(ctx, pkgDir, fuzzCmd, "GODEBUG=fuzzdebug=1")
+	if err != nil {
+		return 0, fmt.Errorf("go test failed for %q: %w ", pkgDir, err)
+	}
+
+	// Parse the fuzz output to extract the initial coverage bits.
+	//
+	// Return the number of coverage bits printed by the Go fuzzing engine
+	// after it finishes processing all inputs in the fuzz cache.
+	coverageRe := regexp.MustCompile(`initial coverage bits:\s+([0-9]+)\n`)
+	matches := coverageRe.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("coverage bits not found in output:\n%s",
+			output)
+	}
+
+	coverage, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("parsing coverage: %w", err)
+	}
+
+	return coverage, nil
+}
+
+// MinimizeCorpus prunes unnecessary seed inputs from the corpus directory
+// while preserving the maximum observed coverage. It works by iteratively
+// testing each seed input (from smallest to largest, greedily) and removing
+// those that do not contribute to improved coverage.
+func MinimizeCorpus(ctx context.Context, logger *slog.Logger, pkgDir, corpusDir,
+	target string) error {
+
+	// Remove the seed fuzz testdata directory to start fresh.
+	fuzzTestDataDir := filepath.Join(pkgDir, "testdata", "fuzz", target)
+	if err := os.RemoveAll(fuzzTestDataDir); err != nil {
+		return fmt.Errorf("removing testdata: %w", err)
+	}
+
+	// Temporary directory for the corpus cache where inputs will be added
+	// one by one to check if they increase coverage.
+	cacheDir, err := os.MkdirTemp("", "go-continuous-fuzz-cache-")
+	if err != nil {
+		return fmt.Errorf("creating temp cache dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			logger.Error("Failed to remove cache", "error", err)
+		}
+	}()
+
+	cacheCorpusDir := filepath.Join(cacheDir, target)
+	if err := EnsureDirExists(cacheCorpusDir); err != nil {
+		return fmt.Errorf("creating cache corpus dir: %w", err)
+	}
+
+	// Read and sort existing corpus files by size, so we iterate from the
+	// smallest to largest input, greedily adding those that improve
+	// coverage.
+	corpusTargetDir := filepath.Join(corpusDir, target)
+	entries, err := os.ReadDir(corpusTargetDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading corpus dir: %w", err)
+	}
+
+	// fileInfo represents the name and size of a file, used for sorting
+	// files by their size.
+	type fileInfo struct {
+		Name string
+		Size int64
+	}
+
+	// Collect file information for sorting by size.
+	var files []fileInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("getting file info for %s: %w",
+				entry.Name(), err)
+		}
+		files = append(files, fileInfo{
+			Name: entry.Name(),
+			Size: info.Size(),
+		})
+	}
+
+	// Sort files from smallest to largest by size.
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Size < files[j].Size
+	})
+
+	bestCoverage := 0
+	removedCount := 0
+
+	// Iterate through each corpus file, measure its impact on coverage,
+	// and remove it if it does not improve or reduces the coverage.
+	for _, file := range files {
+		srcPath := filepath.Join(corpusTargetDir, file.Name)
+		dstPath := filepath.Join(cacheCorpusDir, file.Name)
+
+		// Copy file to temporary corpus directory.
+		if err := copyFile(srcPath, dstPath, logger); err != nil {
+			return fmt.Errorf("copy %q to cache: %w", srcPath, err)
+		}
+
+		// Measure coverage with the current set in the temporary corpus
+		// directory.
+		newCoverage, err := MeasureCoverage(ctx, pkgDir, cacheDir,
+			target)
+		if err != nil {
+			return fmt.Errorf("measuring base coverage: %w", err)
+		}
+
+		if newCoverage > bestCoverage {
+			bestCoverage = newCoverage
+			continue
+		}
+
+		if newCoverage < bestCoverage {
+			logger.Warn("nondeterministic fuzz target: coverage "+
+				"decreased", "file", file.Name, "oldCoverage",
+				bestCoverage, "newCoverage", newCoverage)
+		}
+
+		// Remove the file from both the source and cache directories
+		// since it did not improve coverage or caused a coverage
+		// regression.
+		if err := os.Remove(srcPath); err != nil {
+			return fmt.Errorf("remove %q: %w", srcPath, err)
+		}
+		if err := os.Remove(dstPath); err != nil {
+			return fmt.Errorf("remove %q: %w", dstPath, err)
+		}
+		removedCount++
+	}
+
+	logger.Info("corpus minimization complete", "removedCount",
+		removedCount, "finalCoverage", bestCoverage)
+	return nil
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,14 +4,15 @@
 
 You can configure **go-continuous-fuzz** using either conifg file or command-line flags. All options are listed below:
 
-| Configuration Variable   | Description                                                  | Required | Default |
-| ------------------------ | ------------------------------------------------------------ | -------- | ------- |
-| `project.src-repo`       | Git repo URL of the project to fuzz                          | Yes      | —       |
-| `project.s3-bucket-name` | Name of the S3 bucket where the seed corpus will be stored   | Yes      | —       |
-| `fuzz.crash-repo`        | Git repository URL where issues are created for fuzz crashes | Yes      | —       |
-| `fuzz.pkgs-path`         | List of package paths to fuzz                                | Yes      | —       |
-| `fuzz.sync-frequency`    | Duration between consecutive fuzzing cycles                  | No       | 24h     |
-| `fuzz.num-workers`       | Number of concurrent fuzzing workers                         | No       | 1       |
+| Configuration Variable          | Description                                                  | Required | Default |
+| ------------------------------- | ------------------------------------------------------------ | -------- | ------- |
+| `project.src-repo`              | Git repo URL of the project to fuzz                          | Yes      | —       |
+| `project.s3-bucket-name`        | Name of the S3 bucket where the seed corpus will be stored   | Yes      | —       |
+| `fuzz.crash-repo`               | Git repository URL where issues are created for fuzz crashes | Yes      | —       |
+| `fuzz.pkgs-path`                | List of package paths to fuzz                                | Yes      | —       |
+| `fuzz.sync-frequency`           | Duration between consecutive fuzzing cycles                  | No       | 24h     |
+| `fuzz.num-workers`              | Number of concurrent fuzzing workers                         | No       | 1       |
+| `fuzz.corpus-minimize-interval` | Interval between consecutive corpus minimizations            | No       | 7d      |
 
 **Repository URL formats:**
 For `project.src-repo`:
@@ -98,6 +99,9 @@ The file structure of the coverage reports is as follows:
 6. **Coverage Reports:**
    For each fuzz target, coverage reports are generated and uploaded to the configured AWS S3 bucket (`project.s3-bucket-name`). The bucket can be optionally configured for static website hosting to view reports via a browser.
 
+7. **Coprus Minimization:**
+   To prevent the corpus from becoming bloated over time, it is periodically minimized after every `fuzz.corpus-minimize-interval` where each input is evaluated and those that do not improve or reduce overall coverage are removed.
+
 ## Running go-continuous-fuzz
 
 1. **Clone the Repository**
@@ -120,6 +124,7 @@ The file structure of the coverage reports is as follows:
      --fuzz.pkgs-path=<path/to/pkg>
      --fuzz.sync-frequency=<time>
      --fuzz.num-workers=<number_of_workers>
+     --fuzz.corpus-minimize-interval=<time>
    ```
 
 3. **Run the Fuzzing Engine:**  

--- a/report.go
+++ b/report.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -331,31 +330,4 @@ func copyCorpusFiles(srcDir, dstDir string, logger *slog.Logger) error {
 	}
 
 	return nil
-}
-
-// copyFile copies the contents of a single file from source to destination path
-func copyFile(srcFile, dstFile string, logger *slog.Logger) error {
-	src, err := os.Open(srcFile)
-	if err != nil {
-		return fmt.Errorf("open source file %q: %w", srcFile, err)
-	}
-	defer func() {
-		if err := src.Close(); err != nil {
-			logger.Error("Failed to close file", "error", err)
-		}
-	}()
-
-	dst, err := os.Create(dstFile)
-	if err != nil {
-		return fmt.Errorf("create destination file %q: %w", dstFile,
-			err)
-	}
-	defer func() {
-		if err := dst.Close(); err != nil {
-			logger.Error("Failed to close file", "error", err)
-		}
-	}()
-
-	_, err = io.Copy(dst, src)
-	return err
 }

--- a/sample-go-continuous-fuzz.conf
+++ b/sample-go-continuous-fuzz.conf
@@ -50,3 +50,9 @@
 ;   fuzz.num-workers = 1
 ; Example:
 ;   fuzz.num-workers = 8
+
+; Interval between consecutive corpus minimizations.
+; Default:
+;   fuzz.corpus-minimize-interval = 7d
+; Example:
+;   fuzz.corpus-minimize-interval = 20h

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -7,7 +7,8 @@ set -eux
 # Temporary Variables
 readonly PROJECT_SRC_PATH="https://oauth2:${GO_FUZZING_EXAMPLE_AUTH_TOKEN}@github.com/go-continuous-fuzz/go-fuzzing-example.git"
 readonly SYNC_FREQUENCY="3m"
-readonly MAKE_TIMEOUT="330s"
+readonly CORPUS_MINIMIZE_INTERVAL="4m"
+readonly MAKE_TIMEOUT="9m"
 
 # Use test workspace directory
 readonly TEST_WORKDIR=$(mktemp -dt "test-go-continuous-fuzz-XXXXXX")
@@ -24,6 +25,7 @@ ARGS="\
 --project.src-repo=${PROJECT_SRC_PATH} \
 --project.s3-bucket-name=${BUCKET_NAME} \
 --fuzz.sync-frequency=${SYNC_FREQUENCY} \
+--fuzz.corpus-minimize-interval=${CORPUS_MINIMIZE_INTERVAL} \
 --fuzz.crash-repo=${PROJECT_SRC_PATH} \
 --fuzz.num-workers=3 \
 --fuzz.pkgs-path=parser \
@@ -212,6 +214,11 @@ readonly REQUIRED_PATTERNS=(
   'msg="Successfully added/updated coverage report" package=parser target=FuzzParseComplex'
   'msg="Successfully added/updated coverage report" package=parser target=FuzzEvalExpr'
   'msg="Successfully added/updated coverage report" package=tree target=FuzzBuildTree'
+  'msg="corpus minimization complete" target=FuzzUnSafeReverseString package=stringutils'
+  'msg="corpus minimization complete" target=FuzzReverseString package=stringutils'
+  'msg="corpus minimization complete" target=FuzzParseComplex package=parser'
+  'msg="corpus minimization complete" target=FuzzEvalExpr package=parser'
+  'msg="corpus minimization complete" target=FuzzBuildTree package=tree'
   'Shutdown initiated during fuzzing cycle; performing final cleanup.'
   'msg="Worker starting fuzz target" workerID=1'
   'msg="Worker starting fuzz target" workerID=2'
@@ -254,6 +261,7 @@ readonly FORBIDDEN_PATTERNS=(
   'Cycle duration complete; initiating cleanup.'
   'Corpus object not found. Starting with empty corpus.'
   'warning: starting with empty corpus'
+  'nondeterministic fuzz target: coverage decreased'
 )
 
 # Verify that worker logs do not contain forbidden entries


### PR DESCRIPTION
Closes: #34 

This PR adds support for periodic corpus minimization to prevent it from becoming bloated with unnecessary files. Users can now specify the minimization interval via `fuzz.corpus-minimize-interval`. When the corpus has aged beyond this interval since its last minimization, we trigger minimization by tracking the last-minimized timestamp in the corpus object’s metadata.

## Workflow

1. The scheduler retrieves the corpus from the bucket.

   * If the corpus does not exist, we initialize its last-minimized time to the current time.
   * Otherwise, we read the last-minimized timestamp from the corpus metadata.
2. We determine whether the corpus needs minimization by comparing the current time to the last-minimized time plus the configured interval.
3. If minimization is required:

   * We create a temp directory and copy corpus inputs into it one by one, ordered from smallest to largest.
   * For each input, we measure coverage: if coverage remains the same or decreases, we remove the input from both the corpus and the temp directory.
4. Once minimization is complete, we update the corpus metadata with the new last-minimized timestamp and push the revised corpus back to the S3 bucket.
