### PR TITLE
Handle NotFound and NoSuchKey errors in HeadObject

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -126,7 +126,8 @@ func (s3s *S3Store) getLastMinimizedTime() (time.Time, error) {
 	})
 	if err != nil {
 		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
+		var nf *types.NotFound
+		if errors.As(err, &nsk) || errors.As(err, &nf) {
 			// Object doesn't exist, so default to current time
 			return time.Now(), nil
 		}


### PR DESCRIPTION
Fixes: #46 

`HeadObject` does not return a `NoSuchKey` error when the object does not exist. instead, it returns a `NotFound` error (https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html).