### PR TITLE
Bump Go to 1.24.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23.9"
+          go-version: "1.24.6"
 
       - name: Check gofmt
         run: |
@@ -47,7 +47,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23.9"
+          go-version: "1.24.6"
 
       - name: Set up Go environment variables
         run: |
@@ -71,7 +71,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23.9"
+          go-version: "1.24.6"
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
         id: setup
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23.9"
+          go-version: "1.24.6"
 
       - name: Install dependencies
         run: go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  go: "1.23.9"
+  go: "1.24.6"
   timeout: 10m
 
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image.
-FROM golang:1.23.9 AS build
+FROM golang:1.24.6 AS build
 
 # Install necessary tools and dependencies.
 RUN apt-get update && \

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ const (
 
 	// ContainerImage specifies the Docker image to use for running the
 	// container.
-	ContainerImage = "golang:1.23.9"
+	ContainerImage = "golang:1.24.6"
 
 	// ContainerProjectPath specifies the root directory for the project
 	// inside the container.

--- a/container_test.go
+++ b/container_test.go
@@ -31,7 +31,7 @@ func TestContainerRace(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, cli.Close()) })
 
-	// Pull the golang:1.23.9 image once for both containers.
+	// Pull the golang image once for both containers.
 	reader, err := cli.ImagePull(ctx, ContainerImage,
 		image.PullOptions{})
 	assert.NoError(t, err)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,10 +2,10 @@
 
 ## Installation Instructions
 
-### Step 1: Install Go 1.23.9
+### Step 1: Install Go
 
 1. Visit the official Go download page: [Go Downloads](https://go.dev/dl).
-2. Download and install the appropriate version for your OS and hardware architecture.
+2. Download and install one of the stable versions for your OS and hardware architecture.
 
 ### Step 2: Add GOBIN Path to Your $PATH
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/go-continuous-fuzz/go-continuous-fuzz
 
-go 1.23.9
+go 1.24.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.83
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.83.0
@@ -21,6 +20,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.36.5 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.11 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect

--- a/scheduler.go
+++ b/scheduler.go
@@ -217,7 +217,7 @@ func scheduleFuzzing(ctx context.Context, logger *slog.Logger, cfg *Config,
 		}
 	}()
 
-	// Pull the Docker image specified by ContainerImage ("golang:1.23.9").
+	// Pull the Docker image specified by ContainerImage.
 	reader, err := cli.ImagePull(ctx, ContainerImage,
 		image.PullOptions{})
 	if err != nil {

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -329,7 +329,7 @@ if [[ "${num_crash_files}" -ne 1 ]]; then
 fi
 
 required_crashes=(
-  "testing.go:1591: panic: runtime error: index out of range [6] with length 6"
+  "testing.go:1693: panic: runtime error: index out of range [6] with length 6"
   "stringutils_test.go:17: Reverse produced invalid UTF-8 string"
   "fuzzing process hung or terminated unexpectedly: exit status 2"
 )


### PR DESCRIPTION
Now that 1.25.0 has been released, 1.23.x is no longer considered "stable".