### PR TITLE
Add WorkSpacePath option to specify directory for generated files

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,6 +6,7 @@ You can configure **go-continuous-fuzz** using either conifg file or command-lin
 
 | Configuration Variable          | Description                                                  | Required | Default |
 | ------------------------------- | ------------------------------------------------------------ | -------- | ------- |
+| `project.workspace-path`        | Absolute path to the directory for storing generated files   | No       | —       |
 | `project.src-repo`              | Git repo URL of the project to fuzz                          | Yes      | —       |
 | `project.s3-bucket-name`        | Name of the S3 bucket where the seed corpus will be stored   | Yes      | —       |
 | `fuzz.crash-repo`               | Git repository URL where issues are created for fuzz crashes | Yes      | —       |
@@ -118,6 +119,7 @@ The file structure of the coverage reports is as follows:
    Or pass flags directly:
 
    ```bash
+     --project.workspace-path=</path/to/file>
      --project.src-repo=<project_repo_url>
      --project.s3-bucket-name=<bucket_name>
      --fuzz.crash-repo=<repo_url>
@@ -148,4 +150,5 @@ The file structure of the coverage reports is as follows:
   - `$LOCALAPPDATA/Go-continuous-fuzz/go-continuous-fuzz.conf` on Windows,
   - `~/Library/Application Support/Go-continuous-fuzz/go-continuous-fuzz.conf` on Mac OS
   - `$home/go-continuous-fuzz/go-continuous-fuzz.conf` on Plan9.
+- `project.workspace-path` is completely optional and is mainly used for debugging in case a crash occurs during the last run. If this option is not set, a temporary directory will be used, which will be deleted even if errors occur.
 - For more advanced usage, including Docker integration and running tests, see [INSTALL.md](./INSTALL.md).

--- a/sample-go-continuous-fuzz.conf
+++ b/sample-go-continuous-fuzz.conf
@@ -8,6 +8,12 @@
 
 [Project]
 
+; Absolute path to the directory for storing generated files.
+; Default:
+;   project.workspace-path =
+; Example:
+;   project.workspace-path = ~/go-continuous-fuzz
+
 ; Git URL of the project to fuzz.
 ; Default:
 ;   project.src-repo =

--- a/utils.go
+++ b/utils.go
@@ -37,8 +37,17 @@ func cleanupProjectCorpusAndReport(logger *slog.Logger, cfg *Config) {
 }
 
 // cleanupWorkspace deletes the temp directory to reset the workspace state.
+// If the user specified --workspace-path, the directory is not removed, since
+// keeping it can be useful for debugging crashes in go-continuous-fuzz.
 // Any errors encountered during removal are logged, but do not stop execution.
 func cleanupWorkspace(logger *slog.Logger, cfg *Config) {
+	// If the user specified --workspace-path, do not delete the workspace
+	// directory. This allows the user to preserve files for debugging in
+	// case go-continuous-fuzz crashes.
+	if cfg.Project.WorkSpacePath != "" {
+		return
+	}
+
 	// Since the config has the path to the project directory and we want to
 	// remove its temporary parent directory, we go up one level to its
 	// parent directory.


### PR DESCRIPTION
Fixes: #51 

When an error occurs, the `main` process exits and deletes the temporary workspace directory used to store the files generated by `go-continuous-fuzz`. This makes it difficult to debug the problematic part of the code. To make debugging and understanding the process easier, I created a new option called `project.workspace-path`. If this option is specified, that directory will be used to store the generated files and will not be deleted. If it is not specified, a temporary directory will be used, which will be deleted every time the `main` process exits, even on errors.