### PR TITLE
Ignore SIGPIPE

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,12 @@ func run() int {
 	appCtx, cancelApp := context.WithCancel(context.Background())
 	defer cancelApp()
 
+	// If output is piped to another program and then a SIGINT is sent to
+	// the process group, we will receive a SIGPIPE when the other program
+	// closes the pipe. In that case, we want the below SIGINT handler to
+	// clean things up rather than terminating immediately.
+	signal.Ignore(syscall.SIGPIPE)
+
 	// Set up signal handling for graceful shutdown on SIGINT and SIGTERM.
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
If stdout ever gets closed, a SIGPIPE is received which immediately terminates the program.  This could happen if GCF's output is being piped to another program (e.g., tee) and then the user sends a SIGINT to terminate the process group.  In this case, the pipe would be closed and GCF would receive a SIGPIPE.

By ignoring SIGPIPE, we allow the SIGINT handler to finish running and clean up any current workers.  All writes to stdout (i.e. logging) will fail, so we won't be able to tell from the output whether cleanup was successful.  But from testing manually, all workers were properly shut down.

Fixes #48.